### PR TITLE
Fix missing version key parsing Solid2Model.lights

### DIFF
--- a/gbx_parser.py
+++ b/gbx_parser.py
@@ -1356,7 +1356,7 @@ Chunk_090BB000 = (
                 "u06" / Bytes(12),  # 6*4bytes
                 "u12"
                 / If(
-                    this._.version >= 26, Bytes(12)
+                    this._._.version >= 26, Bytes(12)
                 ),  # 3*4bytes, [1] and [2] = 0 if version < 26
                 "u15" / GbxBool,
                 "u16" / If(this.u15, Bytes(12)),  # 3*4bytes


### PR DESCRIPTION
Key error for 'version' trying to parse Screen1x1 and this fixed it for me. (There were other issues if I didn't set lights to `[]` like in Update_090BB000)